### PR TITLE
added *.hdf, __pycache__ and segments.csv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.hdf
+_pycache__/
+segments.csv
+


### PR DESCRIPTION
It's probably not very important since most people won't use the repo as their actual starting point but still, I like to implement best practices where possible.

I added a .gitignore and added all hdf files, __pycache and segments.csv to it since cache files and temporarily files as well as big data files shouldn't be part of a repo.

Feel free to merge or not.