### PR TITLE
fixed index out of bounds error

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -283,10 +283,17 @@ def main(doc):
     
     #Find indices contained in foreground file
     logging.info(f'Finding injections contained in data')
+    padding_start = padding_end = 30
     dur, idxs = find_injection_times(args.foreground_files,
                                      args.injection_file,
-                                     padding_start=30,
-                                     padding_end=30)
+                                     padding_start,
+                                     padding_end)
+    
+    if idxs.sum() == 0:
+        print(f'No injections found. Stopping evaluation. Your time series'
+        'used to train your model is probably too short. Minimal duration is'
+        f" {padding_start + padding_end + 30} seconds.")
+        return
     
     #Read injection parameters
     logging.info(f'Reading injections from {args.injection_file}')


### PR DESCRIPTION
The following fix introduced a bug in `evaluate.py`:
https://github.com/gwastro/ml-mock-data-challenge-1/blob/1a04d6f2acbc9afb4df2ed828e6d90a1040b3c41/generate_data.py#L617

Also your fix introduced another bug (which probably negates the statement above, bit confused). But basically, if there is no injection then the function find_closest_index in evaluate.py throws an "index out of bounds" error because array is empty i.e. [] . See line 90 which contains: np.fabs(array[lidxs] - value) but since array is empty, we get the index out of bounds error.